### PR TITLE
DM-46627: Downgrade per-row exception logging severity

### DIFF
--- a/python/lsst/multiprofit/fitting/fit_psf.py
+++ b/python/lsst/multiprofit/fitting/fit_psf.py
@@ -634,15 +634,19 @@ class CatalogPsfFitter:
                 column = self.errors_expected.get(e.__class__, "")
                 if column:
                     row[f"{prefix}{column}"] = True
-                    logger.info(
+                    logger.debug(
                         f"{id_source=} ({idx}/{n_rows}) PSF fit failed with known exception={e}"
                     )
                 else:
                     row[f"{prefix}unknown_flag"] = True
-                    logger.warning(
+                    logger.info(
                         f"{id_source=} ({idx}/{n_rows}) PSF fit failed with unexpected exception={e}",
                         exc_info=1,
                     )
+
+        n_unknown = np.sum(row[f"{prefix}unknown_flag"])
+        if n_unknown > 0:
+            logger.warning(f"{n_unknown}/{n_rows} PSF fits failed with unexpected exceptions")
 
         return results
 

--- a/python/lsst/multiprofit/fitting/fit_source.py
+++ b/python/lsst/multiprofit/fitting/fit_source.py
@@ -865,13 +865,18 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
                 column = self.errors_expected.get(e.__class__, "")
                 if column:
                     row[f"{prefix}{column}"] = True
-                    logger.info(f"{id_source=} ({idx=}/{n_rows}) fit failed with known exception={e}")
+                    logger.debug(f"{id_source=} ({idx=}/{n_rows}) fit failed with known exception={e}")
                 else:
                     row[f"{prefix}unknown_flag"] = True
-                    logger.warning(
+                    logger.info(
                         f"{id_source=} ({idx=}/{n_rows}) fit failed with unexpected exception={e}",
                         exc_info=1,
                     )
+
+        n_unknown = np.sum(row[f"{prefix}unknown_flag"])
+        if n_unknown > 0:
+            logger.warning(f"{n_unknown}/{n_rows} PSF fits failed with unexpected exceptions")
+
         return results
 
     def get_channels(


### PR DESCRIPTION
There are often thousands of known exceptions (e.g. for source fits, bad psf fits and/or detect_isPrimary==False) so making them all info-level is overkill.