### PR TITLE
DM-48591: Make column naming schemes more configurable

### DIFF
--- a/python/lsst/multiprofit/componentconfig.py
+++ b/python/lsst/multiprofit/componentconfig.py
@@ -365,6 +365,8 @@ class EllipticalComponentConfig(ShapePriorConfig):
 class GaussianComponentConfig(EllipticalComponentConfig):
     """Configuration for an lsst.gauss2d.fit Gaussian component."""
 
+    _size_label = "sigma"
+
     transform_frac_name = pexConfig.Field[str](
         doc="The name of the reference transform for flux fraction parameters",
         default="log10",
@@ -372,7 +374,7 @@ class GaussianComponentConfig(EllipticalComponentConfig):
     )
 
     def get_size_label(self) -> str:
-        return "sigma"
+        return self._size_label
 
     def get_type_name(self) -> str:
         return "Gaussian"
@@ -469,6 +471,7 @@ class SersicComponentConfig(EllipticalComponentConfig):
         4: _interpolator_class_default(4),
         8: _interpolator_class_default(8),
     }
+    _size_label = "reff"
 
     order = pexConfig.ChoiceField[int](doc="Sersic mix order", allowed={4: "Four", 8: "Eight"}, default=4)
     sersic_index = pexConfig.ConfigField[SersicIndexParameterConfig](doc="Sersic index config")
@@ -496,7 +499,7 @@ class SersicComponentConfig(EllipticalComponentConfig):
         )
 
     def get_size_label(self) -> str:
-        return "reff"
+        return self._size_label
 
     def get_type_name(self) -> str:
         is_gaussian_fixed = self.is_gaussian_fixed()

--- a/python/lsst/multiprofit/fitting/fit_catalog.py
+++ b/python/lsst/multiprofit/fitting/fit_catalog.py
@@ -85,7 +85,64 @@ class CatalogFitterConfig(pexConfig.Config):
         itemtype=str,
         doc="Flag column names to set, keyed by name of exception to catch",
     )
+    naming_scheme = pexConfig.ChoiceField[str](
+        doc="Naming scheme for column names",
+        allowed={
+            "default": "snake_case with {component_name}[_{band}]_{parameter}[_err]",
+            "lsst": "snake_case with [{band}_]{component_name}_{parameter}[Err]",
+        },
+        default="default",
+    )
     prefix_column = pexConfig.Field[str](default="mpf_", doc="Column name prefix")
+    suffix_error = pexConfig.Field[str](
+        default="_err",
+        doc="Default suffix for error columns. Can be overridden by naming_scheme.",
+    )
+
+    _format_flux = {"default": "{prefix}{channel}_flux", "lsst":"{channel}_{prefix}Flux"}
+    _key_cen = {"default": "_cen", "lsst": "Cen"}
+    _key_rho = {"default": "_rho", "lsst": "Rho"}
+    _key_sersicindex = {"default": "_sersic_index", "lsst": "SersicIndex"}
+    _suffix_x = {"default": "_x", "lsst": "X"}
+    _suffix_y = {"default": "_y", "lsst": "Y"}
+
+    def _get_label(self, format_name: str, values: dict[str, str]) -> str:
+        """Get the label for part of a column name for a given format.
+
+        Parameters
+        ----------
+        format_name
+            The name of the format to get the label for.
+        values
+            The values of the name by format.
+
+        Returns
+        -------
+        label
+            The formatted label, if specified for that format, else the
+            value for the default format.
+        """
+        return values.get(format_name, values["default"])
+
+    def get_key_cen(self) -> str:
+        """Get the key for centroid columns."""
+        return self._get_label(self.naming_scheme, self._key_cen)
+
+    def get_key_rho(self) -> str:
+        """Get the key for ellipse rho columns."""
+        return self._get_label(self.naming_scheme, self._key_rho)
+
+    def get_key_sersicindex(self) -> str:
+        """Get the key for Sersic index columns."""
+        return self._get_label(self.naming_scheme, self._key_sersicindex)
+
+    def get_suffix_x(self) -> str:
+        """Get the suffix for x-axis columns."""
+        return self._get_label(self.naming_scheme, self._suffix_x)
+
+    def get_suffix_y(self) -> str:
+        """Get the suffix for y-axis columns."""
+        return self._get_label(self.naming_scheme, self._suffix_y)
 
     def schema(
         self,

--- a/python/lsst/multiprofit/fitting/fit_catalog.py
+++ b/python/lsst/multiprofit/fitting/fit_catalog.py
@@ -248,7 +248,7 @@ class CatalogFitterConfig(pexConfig.Config):
             ColumnInfo(key="time_eval", dtype="f8", unit=u.s),
             ColumnInfo(key="time_fit", dtype="f8", unit=u.s),
             ColumnInfo(key="time_full", dtype="f8", unit=u.s),
-            ColumnInfo(key="chisq_red", dtype="f8"),
+            ColumnInfo(key="chisq_reduced", dtype="f8"),
             ColumnInfo(key="unknown_flag", dtype="bool"),
         ]
         schema.extend([ColumnInfo(key=key, dtype="bool") for key in self.flag_errors.keys()])

--- a/python/lsst/multiprofit/fitting/fit_psf.py
+++ b/python/lsst/multiprofit/fitting/fit_psf.py
@@ -636,7 +636,7 @@ class CatalogPsfFitter:
                 results[f"{prefix}n_iter"][idx] = result_full.n_eval_func
                 results[f"{prefix}time_eval"][idx] = result_full.time_eval
                 results[f"{prefix}time_fit"][idx] = result_full.time_run
-                results[f"{prefix}chisq_red"][idx] = result_full.chisq_best/size
+                results[f"{prefix}chisq_reduced"][idx] = result_full.chisq_best / size
                 if config.config_fit.eval_residual:
                     results[f"{prefix}n_eval_jac"][idx] = result_full.n_eval_jac
 
@@ -650,9 +650,7 @@ class CatalogPsfFitter:
                 column = self.errors_expected.get(e.__class__, "")
                 if column:
                     row[f"{prefix}{column}"] = True
-                    logger.debug(
-                        f"{id_source=} ({idx}/{n_rows}) PSF fit failed with known exception={e}"
-                    )
+                    logger.debug(f"{id_source=} ({idx}/{n_rows}) PSF fit failed with known exception={e}")
                 else:
                     row[f"{prefix}unknown_flag"] = True
                     logger.info(

--- a/python/lsst/multiprofit/fitting/fit_psf.py
+++ b/python/lsst/multiprofit/fitting/fit_psf.py
@@ -234,9 +234,16 @@ class CatalogPsfFitterConfigData(pydantic.BaseModel):
     def parameters(self) -> dict[str, g2f.ParameterD]:
         """Return the free parameters for the PSF model by name."""
         parameters = {}
-        has_prefix_group = self.config.model.has_prefix_group()
+        config = self.config
+        has_prefix_group = config.model.has_prefix_group()
         components = self.psf_model.components
         idx_comp_first = 0
+
+        label_cen = config.get_key_cen()
+        label_rho = config.get_key_rho()
+        label_flux = config.get_key_flux("")
+        label_fluxfrac = f"{label_flux}frac"
+        suffix_x, suffix_y = config.get_suffix_x(), config.get_suffix_y()
 
         # Iterate over each component group
         for name_group, config_group in self.componentgroup_configs.items():
@@ -255,20 +262,28 @@ class CatalogPsfFitterConfigData(pydantic.BaseModel):
                 # The last component needs special handling if is_fractional
                 is_last = idx_comp_group == idx_last
                 component = components[idx_comp_first + idx_comp_group]
-                label_size = config_comp.get_size_label()
-                prefix_comp = f"{prefix_group}{name_comp}{'_' if name_comp else ''}"
+                prefix_comp = f"{prefix_group}{name_comp}"
+                key_size = config.get_prefixed_label(
+                    config.get_key_size(config_comp.get_size_label()),
+                    prefix_comp,
+                )
+                key_rho = config.get_prefixed_label(label_rho, prefix_comp)
+
                 # Give the centroid parameters an appropriate prefix
                 if multicen or (idx_comp_group == 0):
                     prefix_cen = prefix_comp if multicen else prefix_group
-                    parameters[f"{prefix_cen}cen_x"] = component.centroid.x_param
-                    parameters[f"{prefix_cen}cen_y"] = component.centroid.y_param
+                    # Avoid redundant -underscores if there's nothing to prefix
+                    # or an existing prefix starting with an underscore
+                    key_cen = config.get_prefixed_label(label_cen, prefix_cen)
+                    parameters[f"{key_cen}{suffix_x}"] = component.centroid.x_param
+                    parameters[f"{key_cen}{suffix_y}"] = component.centroid.y_param
                 # Add each free shape parameter
                 if not config_comp.size_x.fixed:
-                    parameters[f"{prefix_comp}{label_size}_x"] = component.ellipse.size_x_param
+                    parameters[f"{key_size}{suffix_x}"] = component.ellipse.size_x_param
                 if not config_comp.size_y.fixed:
-                    parameters[f"{prefix_comp}{label_size}_y"] = component.ellipse.size_y_param
+                    parameters[f"{key_size}{suffix_y}"] = component.ellipse.size_y_param
                 if not config_comp.rho.fixed:
-                    parameters[f"{prefix_comp}rho"] = component.ellipse.rho_param
+                    parameters[key_rho] = component.ellipse.rho_param
 
                 # TODO: return this to component.integralmodel
                 # when binding for g2f.FractionalIntegralModel is fixed
@@ -284,7 +299,7 @@ class CatalogPsfFitterConfigData(pydantic.BaseModel):
                         f"{params_flux=} has len={len(params_flux)} but expected {n_params_flux_expect}"
                     )
                 if has_params_flux:
-                    parameters[f"{prefix_comp}flux"] = params_flux[0]
+                    parameters[f"{prefix_comp}{label_flux}"] = params_flux[0]
                 # TODO: return this to component.integralmodel
                 # when binding for g2f.FractionalIntegralModel is fixed
                 params_fluxfrac = [
@@ -302,7 +317,7 @@ class CatalogPsfFitterConfigData(pydantic.BaseModel):
                             )
                     else:
                         if not config_comp.fluxfrac.fixed:
-                            parameters[f"{prefix_comp}fluxfrac"] = params_fluxfrac[-1]
+                            parameters[f"{prefix_comp}{label_fluxfrac}"] = params_fluxfrac[-1]
                             n_params_flux_frac += 1
                     if len(params_fluxfrac) != n_params_flux_frac:
                         raise RuntimeError(

--- a/python/lsst/multiprofit/fitting/fit_source.py
+++ b/python/lsst/multiprofit/fitting/fit_source.py
@@ -267,14 +267,38 @@ class CatalogSourceFitterConfig(CatalogFitterConfig):
             ]
         )
         if self.convert_cen_xy_to_radec:
-            for key, param in parameters.items():
-                suffix = (
-                    "cen_ra"
-                    if isinstance(param, g2f.CentroidXParameterD)
-                    else ("cen_dec" if isinstance(param, g2f.CentroidYParameterD) else None)
+            label_cen = self.get_key_cen()
+            cen_underscored = label_cen.startswith("_")
+            suffix_x, suffix_y, suffix_ra, suffix_dec = (
+                f"{label_cen}{suffix}"
+                for suffix in (
+                    self.get_suffix_x(),
+                    self.get_suffix_y(),
+                    self.get_suffix_ra(),
+                    self.get_suffix_dec(),
                 )
-                if suffix is not None:
-                    schema.append(ColumnInfo(key=f"{key[:-5]}{suffix}", dtype="f8", unit=u.deg))
+            )
+            suffix_ra = f"{label_cen}{self.get_suffix_ra()}"
+            suffix_dec = f"{label_cen}{self.get_suffix_dec()}"
+            for key, param in parameters.items():
+                # TODO: Update if allowing x, y <-> dec, RA mappings
+                # ... or arbitrary rotations
+                suffix_radec, suffix_xy = (
+                    (suffix_ra, suffix_x)
+                    if isinstance(param, g2f.CentroidXParameterD)
+                    else (
+                        (suffix_dec, suffix_y) if isinstance(param, g2f.CentroidYParameterD) else (None, None)
+                    )
+                )
+                if suffix_radec is not None:
+                    # Add whatever the corresponding prefix is, and also
+                    # remove any leading underscore if there's no prefix
+                    prefix, suffix = (
+                        ("", suffix_radec[1:])
+                        if (cen_underscored and (key == suffix_xy[1:]))
+                        else (key.split(suffix_xy)[0], suffix_radec)
+                    )
+                    schema.append(ColumnInfo(key=f"{prefix}{suffix}", dtype="f8", unit=u.deg))
         if self.compute_errors != "NONE":
             suffix = self.suffix_error
             idx_end = len(schema)
@@ -314,16 +338,17 @@ class CatalogSourceFitterConfigData(pydantic.BaseModel):
 
     @cached_property
     def parameters(self) -> dict[str, g2f.ParameterD]:
-        config_model = self.config.config_model
+        config = self.config
+        config_model = config.config_model
         idx_comp_first = 0
         has_prefix_source = config_model.has_prefix_source()
         n_channels = len(self.channels)
         parameters = {}
-        format_lsst = self.config.naming_scheme == "lsst"
-        label_cen = self.config.get_key_cen()
-        label_rho = self.config.get_key_rho()
-        label_sersic = self.config.get_key_sersicindex()
-        label_x, label_y = self.config.get_key_cen()
+
+        label_cen = config.get_key_cen()
+        label_rho = config.get_key_rho()
+        label_sersic = config.get_key_sersicindex()
+        label_x, label_y = config.get_suffix_x(), config.get_suffix_y()
 
         for name_source, config_source in config_model.sources.items():
             prefix_source = f"{name_source}_" if has_prefix_source else ""
@@ -338,23 +363,28 @@ class CatalogSourceFitterConfigData(pydantic.BaseModel):
 
                 for idx_comp_group, (name_comp, config_comp) in enumerate(configs_comp):
                     component = self.components[idx_comp_first + idx_comp_group]
-                    label_size = config_comp.get_size_label()
-                    if format_lsst:
-                        label_size = label_size.capitalize()
-                    else:
-                        label_size = f"{label_size}_"
+
                     key_comp = name_comp if is_multicomp else ""
-                    prefix_comp = f"{prefix_group}{key_comp}{'_' if (key_comp and not format_lsst) else ''}"
+                    prefix_comp = f"{prefix_group}{key_comp}"
+                    key_size = config.get_prefixed_label(
+                        config.get_key_size(config_comp.get_size_label()),
+                        prefix_comp,
+                    )
+                    key_rho = config.get_prefixed_label(label_rho, prefix_comp)
+
                     if multicen or (idx_comp_group == 0):
                         prefix_cen = prefix_comp if multicen else prefix_group
-                        parameters[f"{prefix_cen}{label_cen}{label_x}"] = component.centroid.x_param
-                        parameters[f"{prefix_cen}{label_cen}{label_y}"] = component.centroid.y_param
+                        # Avoid double-underscoring if there's nothing to
+                        # prefix or an existing prefix
+                        key_cen = config.get_prefixed_label(label_cen, prefix_cen)
+                        parameters[f"{key_cen}{label_x}"] = component.centroid.x_param
+                        parameters[f"{key_cen}{label_y}"] = component.centroid.y_param
                     if not config_comp.size_x.fixed:
-                        parameters[f"{prefix_comp}{label_size}{label_x}"] = component.ellipse.size_x_param
+                        parameters[f"{key_size}{label_x}"] = component.ellipse.size_x_param
                     if not config_comp.size_y.fixed:
-                        parameters[f"{prefix_comp}{label_size}{label_y}"] = component.ellipse.size_y_param
+                        parameters[f"{key_size}{label_y}"] = component.ellipse.size_y_param
                     if not config_comp.rho.fixed:
-                        parameters[f"{prefix_comp}{label_rho}"] = component.ellipse.rho_param
+                        parameters[key_rho] = component.ellipse.rho_param
                     if not config_comp.flux.fixed:
                         # TODO: return this to component.integralmodel
                         # when binding for g2f.FractionalIntegralModel is fixed
@@ -362,10 +392,12 @@ class CatalogSourceFitterConfigData(pydantic.BaseModel):
                         if len(params_flux) != n_channels:
                             raise ValueError(f"{params_flux=} len={len(params_flux)} != {n_channels=}")
                         for channel, param_flux in zip(self.channels, params_flux):
-                            key_flux = format_flux.format(prefix=prefix_comp, channel=channel.name)
+                            key_flux = config.get_key_flux(label=prefix_comp, band=channel.name)
                             parameters[key_flux] = param_flux
                     if hasattr(config_comp, "sersic_index") and not config_comp.sersic_index.fixed:
-                        parameters[f"{prefix_comp}{label_sersic}"] = component.sersicindex_param
+                        parameters[config.get_prefixed_label(label_sersic, prefix_comp)] = (
+                            component.sersicindex_param
+                        )
 
         return parameters
 
@@ -410,6 +442,8 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
             Dict of tuple of x, y parameter objects by name.
         compute_errors
             Whether errors will be computed.
+        config
+            The configuration with column formatting parameters.
 
         Returns
         -------
@@ -421,24 +455,36 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
         columns_params_radec = []
         columns_params_radec_err = []
         suffix_err = config.suffix_error
+        key_cen = config.get_key_cen()
+        suffix_x, suffix_y = config.get_suffix_x(), config.get_suffix_y()
+        suffix_ra, suffix_dec = config.get_suffix_ra(), config.get_suffix_dec()
 
         for key_base, (param_cen_x, param_cen_y) in params_radec.items():
+            # Avoid C if there's nothing to prefix
+            # or an existing prefix ending in an underscore
+            key_base_cen = config.get_prefixed_label(f"{key_base}{key_cen}", config.prefix_column)
+
             if param_cen_y is None:
                 raise RuntimeError(
                     f"Fitter failed to find corresponding cen_y param for {key_base=}; is it fixed?"
                 )
             columns_params_radec.append(
-                (f"{key_base}cen_ra", f"{key_base}cen_dec", f"{key_base}cen_x", f"{key_base}cen_y")
+                (
+                    f"{key_base_cen}{suffix_ra}",
+                    f"{key_base_cen}{suffix_dec}",
+                    f"{key_base_cen}{suffix_x}",
+                    f"{key_base_cen}{suffix_y}",
+                )
             )
             if compute_errors:
                 columns_params_radec_err.append(
                     (
-                        f"{key_base}cen_ra{suffix_err}",
-                        f"{key_base}cen_dec{suffix_err}",
-                        f"{key_base}cen_x",
-                        f"{key_base}cen_y",
-                        f"{key_base}cen_x{suffix_err}",
-                        f"{key_base}cen_y{suffix_err}",
+                        f"{key_base_cen}{suffix_ra}{suffix_err}",
+                        f"{key_base_cen}{suffix_dec}{suffix_err}",
+                        f"{key_base_cen}{suffix_x}",
+                        f"{key_base_cen}{suffix_y}",
+                        f"{key_base_cen}{suffix_x}{suffix_err}",
+                        f"{key_base_cen}{suffix_y}{suffix_err}",
                     )
                 )
         return columns_params_radec, columns_params_radec_err
@@ -587,6 +633,10 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
         columns_ceny_err_copy = []
 
         suffix_err = config.suffix_error
+        key_cen = config.get_key_cen()
+        cen_underscored = key_cen.startswith("_")
+        suffix_cenx = f"{key_cen}{config.get_suffix_x()}"
+        suffix_ceny = f"{key_cen}{config.get_suffix_y()}"
 
         # Add each param to appropriate and more specific pre-computed lists
         for key, param in params.items():
@@ -611,10 +661,22 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
             if isinstance(param, g2f.IntegralParameterD):
                 columns_param_flux[key_full] = param
             elif config.convert_cen_xy_to_radec:
+                # Infer the prefix if possible, after checking for a dropped
+                # leading underscore in case there's no prefix
                 if is_cenx:
-                    params_cen_x[f"{key_full[:-5]}"] = param
+                    prefix_cen, suffix_cen = (
+                        ("", key_full)
+                        if (cen_underscored and (key_full == suffix_cenx[1:]))
+                        else key_full.split(suffix_cenx)
+                    )
+                    params_cen_x[prefix_cen] = param
                 elif is_ceny:
-                    params_cen_y[f"{key_full[:-5]}"] = param
+                    prefix_cen, suffix_cen = (
+                        ("", key_full)
+                        if (cen_underscored and (key_full == suffix_ceny[1:]))
+                        else key_full.split(suffix_ceny)
+                    )
+                    params_cen_y[prefix_cen] = param
 
         if config.convert_cen_xy_to_radec:
             assert params_cen_x.keys() == params_cen_y.keys()
@@ -651,7 +713,7 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
         # assert because this is a logic error if it fails
         idx_flag_first = keys.index("unknown_flag")
         idx_flag_last = (
-            next(iter(idx for idx, key in enumerate(keys[idx_flag_first:]) if key.endswith("cen_x")))
+            next(iter(idx for idx, key in enumerate(keys[idx_flag_first:]) if not key.endswith("_flag")))
             + idx_flag_first
         )
         assert idx_flag_last > idx_flag_first
@@ -745,7 +807,8 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
                 # Set all params to best fit values
                 # In case the optimizer doesn't
                 for (key, (param, offset)), value in zip(
-                    columns_param_free.items(), result_full.params_best,
+                    columns_param_free.items(),
+                    result_full.params_best,
                 ):
                     param.value_transformed = value
                     if param not in params_free_missing:
@@ -766,7 +829,8 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
 
                     if params_free_missing:
                         columns_param_flux_fit = {
-                            column: param for column, param in columns_param_flux.items()
+                            column: param
+                            for column, param in columns_param_flux.items()
                             if param not in params_free_missing
                         }
                     else:
@@ -875,7 +939,8 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
 
                         if params_free_missing:
                             columns_err_fitted = [
-                                column for column, param in zip(columns_err, params.values())
+                                column
+                                for column, param in zip(columns_err, params.values())
                                 if param not in params_free_missing
                             ]
                         else:
@@ -913,7 +978,7 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
                                 radec_err -= radec
                                 results[key_ra_err][idx], results[key_dec_err][idx] = np.abs(radec_err)
 
-                results[f"{prefix}chisq_red"][idx] = result_full.chisq_best/size
+                results[f"{prefix}chisq_red"][idx] = result_full.chisq_best / size
                 results[f"{prefix}time_full"][idx] = time.process_time() - time_init
             except Exception as e:
                 size = 0 if fitInputs is None else size_new

--- a/python/lsst/multiprofit/fitting/fit_source.py
+++ b/python/lsst/multiprofit/fitting/fit_source.py
@@ -978,7 +978,7 @@ class CatalogSourceFitterABC(ABC, pydantic.BaseModel):
                                 radec_err -= radec
                                 results[key_ra_err][idx], results[key_dec_err][idx] = np.abs(radec_err)
 
-                results[f"{prefix}chisq_red"][idx] = result_full.chisq_best / size
+                results[f"{prefix}chisq_reduced"][idx] = result_full.chisq_best / size
                 results[f"{prefix}time_full"][idx] = time.process_time() - time_init
             except Exception as e:
                 size = 0 if fitInputs is None else size_new

--- a/python/lsst/multiprofit/modelconfig.py
+++ b/python/lsst/multiprofit/modelconfig.py
@@ -34,7 +34,7 @@ from .sourceconfig import SourceConfig
 class ModelConfig(pexConfig.Config):
     """Configuration for an lsst.gauss2d.fit Model."""
 
-    sources = pexConfig.ConfigDictField[str, SourceConfig](doc="The configuration for sources")
+    sources = pexConfig.ConfigDictField[str, SourceConfig](doc="The configuration for sources", default={})
 
     @staticmethod
     def format_label(label: str, name_source: str) -> str:

--- a/python/lsst/multiprofit/utils.py
+++ b/python/lsst/multiprofit/utils.py
@@ -91,6 +91,7 @@ def set_config_from_dict(
                 del config[key]
     for key, value in overrides.items():
         if isinstance(value, dict):
+            # Note that this only works on a ConfigDict if a value is set
             attr = config[key] if is_config_dict else getattr(config, key)
             set_config_from_dict(attr, value)
         else:

--- a/tests/test_fit_source.py
+++ b/tests/test_fit_source.py
@@ -1,0 +1,71 @@
+# This file is part of multiprofit.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import lsst.gauss2d.fit as g2f
+from lsst.multiprofit import (
+    ComponentGroupConfig, GaussianComponentConfig, ModelConfig, ModelFitConfig, SourceConfig,
+)
+from lsst.multiprofit.fitting.fit_source import CatalogSourceFitterConfig, CatalogSourceFitterConfigData
+from lsst.multiprofit.utils import get_params_uniq
+import pytest
+
+
+@pytest.fixture(scope="module")
+def channels() -> tuple[g2f.Channel]:
+    channels = tuple(g2f.Channel.get(band) for band in ("R", "G", "B"))
+    return channels
+
+
+@pytest.fixture(scope="module")
+def fitter_config() -> CatalogSourceFitterConfig:
+    config = CatalogSourceFitterConfig(
+        config_fit=ModelFitConfig(),
+        config_model=ModelConfig(
+            sources={
+                "": SourceConfig(
+                    component_groups={
+                        "": ComponentGroupConfig(
+                            components_gauss=(
+                                {
+                                    "gauss": GaussianComponentConfig()
+                                }
+                            ),
+                        )
+                    }
+                ),
+            },
+        ),
+    )
+    return config
+
+
+@pytest.fixture(scope="module")
+def fitter_config_data(channels, fitter_config) -> CatalogSourceFitterConfigData:
+    config_data = CatalogSourceFitterConfigData(channels=channels, config=fitter_config)
+    return config_data
+
+
+def test_fitter_config_data(fitter_config_data):
+    parameters = fitter_config_data.parameters
+    assert len(parameters) > 0
+    sources, priors = fitter_config_data.sources_priors
+    same = (p1 is p2 for p1, p2 in zip(parameters.values(), get_params_uniq(sources[0], fixed=False)))
+    assert all(same)


### PR DESCRIPTION
This adds config options to change the error column name suffix and more broadly switch from snake_case, camelCase and lsst (a bit of both) column format schemes.